### PR TITLE
Corrected namespacing function

### DIFF
--- a/src/Esensi/Core/Traits/PackagedTrait.php
+++ b/src/Esensi/Core/Traits/PackagedTrait.php
@@ -131,7 +131,7 @@ trait PackagedTrait{
         // Get the package namespace or default to the root
         $namespace = $loader->get('esensi::core.namespace', 'esensi::');
         $line = str_singular($this->package) . '.namespace';
-        return $loader->get($namespace . $line, $namespace);
+        return $loader->get($line, $namespace);
     }
 
     /**


### PR DESCRIPTION
When testing this in a new app, when trying to show templates on the app, and not on the esensi namespace, I had some errors. I traced back to this point, where it was always loading the namespace as esensi::

This corrected the problem for me, but not sure if it's correct for everything. My own app template work, and also the backend screens provided by Esensi.
