### PR TITLE
Optimize Repository Read

### DIFF
--- a/src/Traits/FindableRepositoryTrait.php
+++ b/src/Traits/FindableRepositoryTrait.php
@@ -115,8 +115,8 @@ trait FindableRepositoryTrait
      */
     public function findWithRelated($id, array $relationship)
     {
-        // Get the resource
-        $object = $this->read($id);
+        // Get the resource; since we're explicitly loading relationships, make sure to get a fresh copy from the DB
+        $object = $this->read($id, true);
 
         // Throw an exception if the relationship is not related
         foreach($relationship as $related)

--- a/src/Traits/ResourcefulRepositoryTrait.php
+++ b/src/Traits/ResourcefulRepositoryTrait.php
@@ -42,12 +42,14 @@ trait ResourcefulRepositoryTrait
     /**
      * Display the specified resource.
      *
-     * @param integer $id of resource
+     * @param integer|Esensi\Core\Models\Model $id of resource or instance
+     * @param boolean                          $refresh force loading a fresh copy of resource from the DB
+     *
      * @return Esensi\Core\Models\Model
      */
-    public function show($id)
+    public function show($id, $refresh = false)
     {
-        return $this->read($id);
+        return $this->read($id, $refresh);
     }
 
     /**


### PR DESCRIPTION
Repository read methods can pass through instances of Model and cache query results