### PR TITLE
Remove hardcoded value for base model’s table

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -29,7 +29,7 @@ class Model extends BaseModel
      *
      * @var string
      */
-    protected $table = 'models';
+    protected $table;
 
     /**
      * The relationships that should be eager loaded with each query.


### PR DESCRIPTION
Having this value set breaks expected behavior of allowing a model to generate its own table name.
This should not break any existing code as, for that code to work already, it would have had to overwrite this value anyways.